### PR TITLE
fix Gem::Package::TarWriter::FileOverflow error

### DIFF
--- a/lib/et/lesson.rb
+++ b/lib/et/lesson.rb
@@ -24,7 +24,7 @@ module ET
                     tar.mkdir(relative_path, 0755)
                   else
                     file_contents = File.read(file)
-                    tar.add_file_simple("./" + relative_path, 0555, file_contents.length) do |io|
+                    tar.add_file_simple("./" + relative_path, 0555, file_contents.bytesize) do |io|
                       io.write(file_contents)
                     end
                   end


### PR DESCRIPTION
Some students were receiving an error on `rescue-mission` when trying to `et submit`. This was an issue with the `Lesson#archive!` method, where some files had greater `.bytesize` than `.length`. We will now use `.bytesize` instead.

The error is: `Gem::Package::TarWriter::FileOverflow: You tried to feed more data than fits in the file.`